### PR TITLE
cleanup

### DIFF
--- a/cmd/firebase-ctl/applyConfig.go
+++ b/cmd/firebase-ctl/applyConfig.go
@@ -18,18 +18,17 @@ var applyConfig = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error while getting firebase app: %s", err.Error())
 		}
-		cfg, err:= clientStore.GetLocalConfig(inputDir)
-		if err!= nil{
-			log.Fatal("error getting latest config",err)
+		cfg, err := clientStore.GetLocalConfig(inputDir)
+		if err != nil {
+			log.Fatal("error getting latest config", err)
 			return
 		}
 		err = clientStore.ApplyConfig(*cfg)
 		if err != nil {
-			log.Fatal("error applying latest config" ,err)
+			log.Fatal("error applying latest config", err)
 			return
 		}
 		log.Printf("%s remote config applied successfully%s", utils.Green, utils.Reset)
-
 
 	},
 }
@@ -39,4 +38,3 @@ func init() {
 	applyConfig.PersistentFlags().StringVar(&inputDir, "input-dir", "", "Path to output directory")
 	applyConfig.MarkPersistentFlagRequired("input-dir")
 }
-

--- a/cmd/firebase-ctl/diffRemoteConfig.go
+++ b/cmd/firebase-ctl/diffRemoteConfig.go
@@ -8,7 +8,6 @@ import (
 	"log"
 )
 
-
 var diffRemoteConfigCmd = &cobra.Command{
 	Use:   "remote-config",
 	Short: "backup remote-config resources from Firebase project",

--- a/cmd/firebase-ctl/getRemoteConfig.go
+++ b/cmd/firebase-ctl/getRemoteConfig.go
@@ -27,7 +27,7 @@ var getRemoteConfigCmd = &cobra.Command{
 			log.Fatalf("%serror getting latest remote config: %s%s", utils.Red, err.Error(), utils.Reset)
 		}
 		err = clientStore.BackupRemoteConfig(latestRemoteConfig, outputDir)
-		if err!= nil{
+		if err != nil {
 			log.Fatalf("%serror backing up remote config: %s%s", utils.Red, err.Error(), utils.Reset)
 		}
 		log.Printf("%ssuccessfully backed up the config to %s%s", utils.Green, outputDir, utils.Reset)

--- a/cmd/firebase-ctl/validateConfig.go
+++ b/cmd/firebase-ctl/validateConfig.go
@@ -23,8 +23,8 @@ var validateConfig = &cobra.Command{
 			log.Printf("%sremote will not be available%s", utils.Red, utils.Reset)
 		}
 		localConfig, err := clientStore.GetLocalConfig(inputDir)
-		if err!= nil{
-			log.Fatalf("%serror reading config from local: %s%s",utils.Red,  err.Error(), utils.Reset)
+		if err != nil {
+			log.Fatalf("%serror reading config from local: %s%s", utils.Red, err.Error(), utils.Reset)
 		}
 		errs := utils.ValidateParameters(localConfig.Parameters)
 		if len(errs) != 0 {
@@ -32,11 +32,11 @@ var validateConfig = &cobra.Command{
 			for j := range errs {
 				errStringBuilder.WriteString("\n\t" + errs[j].Error())
 			}
-			log.Fatalf("%serror validating parameter values: %s%s", utils.Red,  errStringBuilder.String(), utils.Reset)
+			log.Fatalf("%serror validating parameter values: %s%s", utils.Red, errStringBuilder.String(), utils.Reset)
 			return
 		}
 		log.Printf("%sConfigValidation: Local validation successful %s", utils.Green, utils.Reset)
-		if _, err := config.GetFirebaseConfig();err !=nil{
+		if _, err := config.GetFirebaseConfig(); err != nil {
 			log.Printf("cannot initiate remoteConfigClient: %s", err.Error())
 		}
 		err = clientStore.ValidateOnRemote(*localConfig)
@@ -44,8 +44,7 @@ var validateConfig = &cobra.Command{
 			log.Fatal("error validating with remote api", err)
 			return
 		}
-		log.Printf("%sRemote validation successful %s", utils.Green, utils.Reset )
-
+		log.Printf("%sRemote validation successful %s", utils.Green, utils.Reset)
 
 	},
 }
@@ -55,4 +54,3 @@ func init() {
 	validateConfig.PersistentFlags().StringVar(&inputDir, "input-dir", "", "Path to input directory")
 	validateConfig.MarkPersistentFlagRequired("input-dir")
 }
-

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -1,7 +1,7 @@
 package config
 
 const FIREBASE_AUTH_ENV_VAR = "GOOGLE_APPLICATION_CREDENTIALS"
-const ConditionsDir  = "conditions"
-const ParametersDir  = "parameters"
+const ConditionsDir = "conditions"
+const ParametersDir = "parameters"
 const ConditionsFile = "conditions.json"
 const ParametersFile = "parameters.json"

--- a/internal/firebase/client.go
+++ b/internal/firebase/client.go
@@ -2,8 +2,11 @@ package firebase
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
 	firebase "github.com/rapido-labs/firebase-admin-go/v4"
 	"github.com/rapido-labs/firebase-admin-go/v4/remoteconfig"
 	"github.com/rapido-labs/firebase-ctl/internal/config"
@@ -11,28 +14,24 @@ import (
 	"github.com/rapido-labs/firebase-ctl/internal/utils"
 	"github.com/spf13/afero"
 	"google.golang.org/api/option"
-	"path/filepath"
-	"strings"
-	"time"
 )
 
 type ClientStore struct {
 	remoteConfigClient ConfigClient
-	//fsClient           afero.Fs
 	customFs           *customFs
 }
-func (cs *ClientStore) isRemoteEnabled() bool{
+
+func (cs *ClientStore) isRemoteEnabled() bool {
 	return cs.remoteConfigClient != nil
 }
 func (cs *ClientStore) GetLatestRemoteConfig() (*remoteconfig.RemoteConfig, error) {
-	if !cs.isRemoteEnabled(){
+	if !cs.isRemoteEnabled() {
 		return nil, fmt.Errorf("remote client is not configured")
 	}
 	latestRemoteConfigResponse, err := cs.remoteConfigClient.GetRemoteConfig("")
 	if err != nil {
 		return nil, err
 	}
-
 
 	return latestRemoteConfigResponse.RemoteConfig, err
 }
@@ -50,7 +49,7 @@ func (cs *ClientStore) BackupRemoteConfig(rc *remoteconfig.RemoteConfig, outputD
 		sourceDump.Parameters[i] = parameter
 	}
 	conditionsFilePath := filepath.Join(outputDir, config.ConditionsDir, config.ConditionsFile)
-	err := cs.customFs.WriteJsonToFile(sourceDump.Conditions,conditionsFilePath)
+	err := cs.customFs.WriteJsonToFile(sourceDump.Conditions, conditionsFilePath)
 	if err != nil {
 		return fmt.Errorf("error writing to conditions file: %v", err.Error())
 	}
@@ -64,7 +63,7 @@ func (cs *ClientStore) BackupRemoteConfig(rc *remoteconfig.RemoteConfig, outputD
 func (cs *ClientStore) GetLocalConfig(dir string) (*model.Config, error) {
 	remoteConfig := &model.Config{
 		Conditions:      []model.Condition{},
-		Parameters: map[string]model.Parameter{},
+		Parameters:      map[string]model.Parameter{},
 		ParameterGroups: nil,
 	}
 	conditionsFilePath := filepath.Join(dir, config.ConditionsDir, config.ConditionsFile)
@@ -78,7 +77,7 @@ func (cs *ClientStore) GetLocalConfig(dir string) (*model.Config, error) {
 	return remoteConfig, err
 }
 func (cs *ClientStore) pushConfigToRemote(rc remoteconfig.RemoteConfig, validateOnly bool) error {
-	if !cs.isRemoteEnabled(){
+	if !cs.isRemoteEnabled() {
 		return fmt.Errorf("remote client not implemented")
 	}
 	template := remoteconfig.Template{
@@ -103,11 +102,11 @@ func (cs *ClientStore) pushConfigToRemote(rc remoteconfig.RemoteConfig, validate
 	return nil
 
 }
-func (cs *ClientStore)ValidateOnRemote(sourceConfig model.Config)error{
+func (cs *ClientStore) ValidateOnRemote(sourceConfig model.Config) error {
 	rc := sourceConfig.ToRemoteConfig()
 	return cs.pushConfigToRemote(*rc, true)
 }
-func (cs *ClientStore)ApplyConfig(sourceConfig model.Config)error{
+func (cs *ClientStore) ApplyConfig(sourceConfig model.Config) error {
 	rc := sourceConfig.ToRemoteConfig()
 	return cs.pushConfigToRemote(*rc, false)
 }
@@ -149,11 +148,11 @@ func getFirebaseApp(ctx context.Context) (*firebase.App, error) {
 func GetClientStore(ctx context.Context) (*ClientStore, error) {
 	firebaseApp, err := getFirebaseApp(ctx)
 	if err != nil {
-		return nil , errors.New(fmt.Sprintf("error creating firebase remote config app: %v", err.Error()))
+		return nil, fmt.Errorf("error creating firebase remote config app: %v", err.Error())
 	}
 	client, err := firebaseApp.RemoteConfig(ctx)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("error creating firebase remote config client: %v", err.Error()))
+		return nil, fmt.Errorf("error creating firebase remote config client: %v", err.Error())
 	}
 	return &ClientStore{remoteConfigClient: client, customFs: &customFs{afero.NewOsFs()}}, nil
 }

--- a/internal/firebase/client_test.go
+++ b/internal/firebase/client_test.go
@@ -3,17 +3,18 @@ package firebase
 import (
 	"context"
 	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
 	"github.com/rapido-labs/firebase-admin-go/v4/remoteconfig"
 	"github.com/rapido-labs/firebase-ctl/internal/model"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"testing"
-	"time"
 )
 
 type ClientMock struct {
@@ -81,7 +82,7 @@ func (c *ClientTestSuite) TestBackupToFsSuccess() {
 	cs := ClientStore{remoteConfigClient: c.mock, customFs: &customFs{tempFs}}
 	dummyResponse := &remoteconfig.Response{
 		RemoteConfig: &remoteconfig.RemoteConfig{
-			Conditions: []remoteconfig.Condition{remoteconfig.Condition{
+			Conditions: []remoteconfig.Condition{{
 				Expression: "hello",
 				Name:       "there",
 				TagColor:   remoteconfig.Blue,
@@ -121,7 +122,7 @@ func (c *ClientTestSuite) TestBackupToFsFailureBecauseFSErrors() {
 	cs := ClientStore{remoteConfigClient: c.mock, customFs: &customFs{fs: tempFs}}
 	dummyResponse := &remoteconfig.Response{
 		RemoteConfig: &remoteconfig.RemoteConfig{
-			Conditions: []remoteconfig.Condition{remoteconfig.Condition{
+			Conditions: []remoteconfig.Condition{{
 				Expression: "hello",
 				Name:       "there",
 				TagColor:   remoteconfig.Blue,
@@ -208,13 +209,13 @@ func (c *ClientTestSuite) TestGetLocalConfig() {
 
 func (c *ClientTestSuite) TestBackup() {
 	configToWrite := remoteconfig.RemoteConfig{
-		Conditions: []remoteconfig.Condition{remoteconfig.Condition{
+		Conditions: []remoteconfig.Condition{{
 			Expression: "a==b",
 			Name:       "test_name",
 			TagColor:   remoteconfig.Blue,
 		}},
 		Parameters: map[string]remoteconfig.Parameter{
-			"string": remoteconfig.Parameter{
+			"string": {
 				ConditionalValues: nil,
 				DefaultValue: &remoteconfig.ParameterValue{
 					ExplicitValue:   "test_value",
@@ -222,7 +223,7 @@ func (c *ClientTestSuite) TestBackup() {
 				},
 				Description: "test_description",
 			},
-			"json": remoteconfig.Parameter{
+			"json": {
 				ConditionalValues: nil,
 				DefaultValue: &remoteconfig.ParameterValue{
 					ExplicitValue:   "{}",
@@ -252,7 +253,7 @@ func (c *ClientTestSuite) TestBackup() {
 	localConfig, err := cs.GetLocalConfig("test")
 	assert.NoError(c.T(), err)
 	assert.Equal(c.T(), configToWrite.Conditions, localConfig.ToRemoteConfig().Conditions)
-	assert.Equal(c.T(), configToWrite.Parameters,localConfig.ToRemoteConfig().Parameters)
+	assert.Equal(c.T(), configToWrite.Parameters, localConfig.ToRemoteConfig().Parameters)
 
 }
 

--- a/internal/firebase/fs.go
+++ b/internal/firebase/fs.go
@@ -9,34 +9,33 @@ import (
 	"strings"
 )
 
-type customFs struct{
+type customFs struct {
 	fs afero.Fs
-
 }
 
-func (f *customFs) UnMarshalFromDir(dirName string, data interface{}) error{
+func (f *customFs) UnMarshalFromDir(dirName string, data interface{}) error {
 	dir, err := f.fs.Open(dirName)
-	if err != nil{
+	if err != nil {
 		return err
 	}
 	defer dir.Close()
 	fileInfoList, err := dir.Readdir(0)
-	if err!= nil{
+	if err != nil {
 		return err
 	}
 	var errs []error
-	for _, fileInfo := range fileInfoList{
-		if fileInfo.IsDir(){
+	for _, fileInfo := range fileInfoList {
+		if fileInfo.IsDir() {
 			continue
 		}
-		err = f.UnmarshalFromFile(filepath.Join(dirName,fileInfo.Name()), data)
-		if err!= nil{
+		err = f.UnmarshalFromFile(filepath.Join(dirName, fileInfo.Name()), data)
+		if err != nil {
 			errs = append(errs, err)
 		}
 	}
-	if len(errs) != 0{
+	if len(errs) != 0 {
 		sb := strings.Builder{}
-		for i := range errs{
+		for i := range errs {
 			sb.WriteString("\n\t" + errs[i].Error())
 		}
 		return errors.New(sb.String())
@@ -44,18 +43,18 @@ func (f *customFs) UnMarshalFromDir(dirName string, data interface{}) error{
 	return nil
 
 }
-func (f *customFs) UnmarshalFromFile(fileName string, data interface{}) error{
+func (f *customFs) UnmarshalFromFile(fileName string, data interface{}) error {
 	file, err := f.fs.Open(fileName)
-	if err!= nil{
+	if err != nil {
 		return err
 	}
 	defer file.Close()
 	return json.NewDecoder(file).Decode(data)
 }
-func (f *customFs)WriteJsonToFile(data interface{}, filePath string)error{
+func (f *customFs) WriteJsonToFile(data interface{}, filePath string) error {
 	f.fs.MkdirAll(filepath.Dir(filePath), 0744)
-	file, err := f.fs.OpenFile(filePath, os.O_RDWR| os.O_CREATE| os.O_TRUNC,0644 )
-	if err!= nil{
+	file, err := f.fs.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
 		return err
 	}
 	defer file.Close()

--- a/internal/firebase/fs_test.go
+++ b/internal/firebase/fs_test.go
@@ -1,12 +1,13 @@
 package firebase
 
 import (
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
 type FsTestSuite struct {
@@ -17,9 +18,9 @@ type FsTestSuite struct {
 func (c *FsTestSuite) SetupTest() {
 	c.fs = afero.NewMemMapFs()
 
-	c.fs.Mkdir(correctJsonsDir, 0644)
+	c.fs.Mkdir(correctJsonDir, 0644)
 	c.fs.MkdirAll(filepath.Join(wrongJsonDir, "test"), 0644)
-	f, _ := c.fs.OpenFile(filepath.Join(correctJsonsDir, "1.json"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
+	f, _ := c.fs.OpenFile(filepath.Join(correctJsonDir, "1.json"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
 	defer f.Close()
 	f.WriteString("{}")
 	g, _ := c.fs.OpenFile(filepath.Join(wrongJsonDir, "1.json"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
@@ -27,21 +28,20 @@ func (c *FsTestSuite) SetupTest() {
 	g.WriteString("{")
 }
 
-const correctJsonsDir = "correct-json"
+const correctJsonDir = "correct-json"
 const wrongJsonDir = "wrong-json"
-const testDir = ""
 
 func (c *FsTestSuite) TestReadJsonFromFile() {
 	customFs := customFs{fs: c.fs}
 
 	c.T().Run("Should unmarshal successfully", func(t *testing.T) {
 		sampleMap := make(map[string]interface{})
-		err := customFs.UnmarshalFromFile(filepath.Join(correctJsonsDir, "1.json"), &sampleMap)
+		err := customFs.UnmarshalFromFile(filepath.Join(correctJsonDir, "1.json"), &sampleMap)
 		assert.NoError(t, err)
 	})
 	c.T().Run("Should exit because invalid file", func(t *testing.T) {
 		sampleMap := make(map[string]interface{})
-		err := customFs.UnmarshalFromFile(filepath.Join(correctJsonsDir, "2.json"), &sampleMap)
+		err := customFs.UnmarshalFromFile(filepath.Join(correctJsonDir, "2.json"), &sampleMap)
 		assert.Contains(t, err.Error(), "does not exist")
 	})
 
@@ -66,7 +66,7 @@ func (c *FsTestSuite) TestReadDirAndUnMarshal() {
 	customFs := customFs{fs: c.fs}
 	c.T().Run("test should scan the directory with only jsons and return all values", func(t *testing.T) {
 
-		err := customFs.UnMarshalFromDir(correctJsonsDir, &map[string]interface{}{})
+		err := customFs.UnMarshalFromDir(correctJsonDir, &map[string]interface{}{})
 		assert.NoError(t, err)
 	})
 	c.T().Run("test should return error when there is invalid json", func(t *testing.T) {
@@ -78,7 +78,7 @@ func (c *FsTestSuite) TestReadDirAndUnMarshal() {
 		assert.Contains(t, err.Error(), "does not exist")
 	})
 	c.T().Run("test should error out when a filepath is passed instead of a directory path", func(t *testing.T) {
-		err := customFs.UnMarshalFromDir(filepath.Join(correctJsonsDir, "1.json"), &map[string]interface{}{})
+		err := customFs.UnMarshalFromDir(filepath.Join(correctJsonDir, "1.json"), &map[string]interface{}{})
 		assert.Error(t, err)
 	})
 }

--- a/internal/firebase/fs_test.go
+++ b/internal/firebase/fs_test.go
@@ -12,19 +12,17 @@ import (
 type FsTestSuite struct {
 	suite.Suite
 	fs afero.Fs
-
 }
 
-func (c *FsTestSuite)SetupTest(){
+func (c *FsTestSuite) SetupTest() {
 	c.fs = afero.NewMemMapFs()
-
 
 	c.fs.Mkdir(correctJsonsDir, 0644)
 	c.fs.MkdirAll(filepath.Join(wrongJsonDir, "test"), 0644)
-	f, _ := c.fs.OpenFile(filepath.Join(correctJsonsDir, "1.json"), os.O_CREATE|os.O_TRUNC|os.O_RDWR,0644)
+	f, _ := c.fs.OpenFile(filepath.Join(correctJsonsDir, "1.json"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
 	defer f.Close()
 	f.WriteString("{}")
-	g, _ := c.fs.OpenFile(filepath.Join(wrongJsonDir, "1.json"), os.O_CREATE|os.O_TRUNC|os.O_RDWR,0644)
+	g, _ := c.fs.OpenFile(filepath.Join(wrongJsonDir, "1.json"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
 	defer g.Close()
 	g.WriteString("{")
 }
@@ -32,24 +30,24 @@ func (c *FsTestSuite)SetupTest(){
 const correctJsonsDir = "correct-json"
 const wrongJsonDir = "wrong-json"
 const testDir = ""
-func (c *FsTestSuite)TestReadJsonFromFile(){
+
+func (c *FsTestSuite) TestReadJsonFromFile() {
 	customFs := customFs{fs: c.fs}
 
 	c.T().Run("Should unmarshal successfully", func(t *testing.T) {
 		sampleMap := make(map[string]interface{})
-		err := customFs.UnmarshalFromFile(filepath.Join(correctJsonsDir,"1.json"),&sampleMap)
+		err := customFs.UnmarshalFromFile(filepath.Join(correctJsonsDir, "1.json"), &sampleMap)
 		assert.NoError(t, err)
 	})
 	c.T().Run("Should exit because invalid file", func(t *testing.T) {
 		sampleMap := make(map[string]interface{})
-		err := customFs.UnmarshalFromFile(filepath.Join(correctJsonsDir,"2.json"),&sampleMap)
+		err := customFs.UnmarshalFromFile(filepath.Join(correctJsonsDir, "2.json"), &sampleMap)
 		assert.Contains(t, err.Error(), "does not exist")
 	})
 
-
 }
 
-func (c *FsTestSuite)TestWriteJsonToFile(){
+func (c *FsTestSuite) TestWriteJsonToFile() {
 
 	customFs := customFs{fs: c.fs}
 
@@ -64,7 +62,7 @@ func (c *FsTestSuite)TestWriteJsonToFile(){
 	})
 }
 
-func(c *FsTestSuite)TestReadDirAndUnMarshal(){
+func (c *FsTestSuite) TestReadDirAndUnMarshal() {
 	customFs := customFs{fs: c.fs}
 	c.T().Run("test should scan the directory with only jsons and return all values", func(t *testing.T) {
 
@@ -77,15 +75,14 @@ func(c *FsTestSuite)TestReadDirAndUnMarshal(){
 	})
 	c.T().Run("test should return error when a non-existent directory is used", func(t *testing.T) {
 		err := customFs.UnMarshalFromDir("some-random-dir", &map[string]interface{}{})
-		assert.Contains(t, err.Error(),"does not exist")
+		assert.Contains(t, err.Error(), "does not exist")
 	})
 	c.T().Run("test should error out when a filepath is passed instead of a directory path", func(t *testing.T) {
-		err:= customFs.UnMarshalFromDir(filepath.Join(correctJsonsDir, "1.json"), &map[string]interface{}{})
+		err := customFs.UnMarshalFromDir(filepath.Join(correctJsonsDir, "1.json"), &map[string]interface{}{})
 		assert.Error(t, err)
 	})
 }
 
-func TestFs(t *testing.T){
+func TestFs(t *testing.T) {
 	suite.Run(t, new(FsTestSuite))
 }
-

--- a/internal/model/local.go
+++ b/internal/model/local.go
@@ -111,7 +111,7 @@ func convertSourceParamsToRemote(p map[string]Parameter) map[string]remoteconfig
 				UseInAppDefault: conditionalValueValue.UseInAppDefault,
 			}
 		}
-		if len(cv) == 0{
+		if len(cv) == 0 {
 			cv = nil
 		}
 		rcParams[parameterKey] = remoteconfig.Parameter{
@@ -151,7 +151,7 @@ func convertRemoteParamsToSource(p map[string]remoteconfig.Parameter) map[string
 				UseInAppDefault: conditionalValueValue.UseInAppDefault,
 			}
 		}
-		if len(cv) == 0{
+		if len(cv) == 0 {
 			cv = nil
 		}
 		rcParams[oarameterKey] = Parameter{

--- a/internal/utils/diff_test.go
+++ b/internal/utils/diff_test.go
@@ -11,9 +11,9 @@ type DiffTestSuite struct {
 	suite.Suite
 }
 
-func (c *DiffTestSuite)SetupTest() {}
+func (c *DiffTestSuite) SetupTest() {}
 
-func (c *DiffTestSuite)TestConditionsDiff()  {
+func (c *DiffTestSuite) TestConditionsDiff() {
 	//nil and nil
 	diff := GetRemoteDiffForConditions(nil, nil)
 	assert.Equal(c.T(), "", diff)
@@ -32,7 +32,7 @@ func (c *DiffTestSuite)TestConditionsDiff()  {
 		Expression: "abcd",
 		Name:       "name1",
 		TagColor:   "BLUE",
-	},{
+	}, {
 		Expression: "efgh",
 		Name:       "name2",
 		TagColor:   "GREEN",
@@ -41,7 +41,7 @@ func (c *DiffTestSuite)TestConditionsDiff()  {
 		Expression: "abcd",
 		Name:       "name1",
 		TagColor:   "BLUE",
-	},{
+	}, {
 		Expression: "efgh",
 		Name:       "name2",
 		TagColor:   "GREEN",
@@ -50,8 +50,6 @@ func (c *DiffTestSuite)TestConditionsDiff()  {
 	assert.Equal(c.T(), "", diff)
 }
 
-
 func Test_Suite(t *testing.T) {
 	suite.Run(t, new(DiffTestSuite))
 }
-

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -7,18 +7,16 @@ import (
 	"strings"
 )
 
-
-
-
-func ValidateParameters(parameters map[string]model.Parameter)[]error{
+func ValidateParameters(parameters map[string]model.Parameter) []error {
 	errs := []error{}
-	for k, v := range parameters{
-		switch strings.ToLower(v.ValueType){
-		case "string": continue
+	for k, v := range parameters {
+		switch strings.ToLower(v.ValueType) {
+		case "string":
+			continue
 		case "json":
 			err := validateJsonParameter(v)
-			if err!= nil{
-				errs = append(errs, fmt.Errorf(	"invalid json for key %s. error:%s",k, err.Error()))
+			if err != nil {
+				errs = append(errs, fmt.Errorf("invalid json for key %s. error:%s", k, err.Error()))
 			}
 		default:
 			errs = append(errs, fmt.Errorf("invalid value type for key:%s", k))
@@ -27,15 +25,15 @@ func ValidateParameters(parameters map[string]model.Parameter)[]error{
 	return errs
 }
 
-func validateJsonParameter(parameter model.Parameter)error{
+func validateJsonParameter(parameter model.Parameter) error {
 	var a json.RawMessage
 	err := json.Unmarshal([]byte(parameter.DefaultValue.ExplicitValue), &a)
-	if err!= nil{
+	if err != nil {
 		return fmt.Errorf("invalid json in default value. %s", err.Error())
 	}
-	for i,cv := range parameter.ConditionalValues{
+	for i, cv := range parameter.ConditionalValues {
 		err := json.Unmarshal([]byte(cv.ExplicitValue), &a)
-		if err!= nil{
+		if err != nil {
 			return fmt.Errorf("invalid json in conditional values. key:%s. error: %s", i, err.Error())
 		}
 	}

--- a/internal/utils/validation_test.go
+++ b/internal/utils/validation_test.go
@@ -21,14 +21,14 @@ func (c *ValidationTestSuite) TestParameters() {
 	parameters := make(map[string]model.Parameter)
 	parameters["validJson"] = model.Parameter{
 		ConditionalValues: map[string]model.ParameterValue{"abcde": {
-								ExplicitValue:   "{}",
-								UseInAppDefault: false,
-							}},
+			ExplicitValue:   "{}",
+			UseInAppDefault: false,
+		}},
 		DefaultValue: &model.ParameterValue{ExplicitValue: "{}"},
 		Description:  "TestDescription",
 		ValueType:    "json",
 	}
-	parameters["validArray"]=  model.Parameter{
+	parameters["validArray"] = model.Parameter{
 		ConditionalValues: map[string]model.ParameterValue{"abcde": {
 			ExplicitValue:   "[]",
 			UseInAppDefault: false,


### PR DESCRIPTION
-  use fmt.Errorf and minor clean ups | Adarsh
- Formatted code | Adarsh
- Fix typo in var and remove un-used var | Adarsh
